### PR TITLE
This PR adds the DQ_CoppeliaSimInterface class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 PROJECT(dqrobotics-interface-coppeliasim)
-set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD 11)
 
 ################################################################
 # INSTALL HEADERS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
-PROJECT(dqrobotics-interface-coppeliasim)
+PROJECT(cpp-interface-coppeliasim)
 set (CMAKE_CXX_STANDARD 11)
 
 ################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
+PROJECT(dqrobotics-interface-coppeliasim)
+set (CMAKE_CXX_STANDARD 14)
+
+################################################################
+# INSTALL HEADERS
+################################################################
+
+INSTALL(FILES
+    include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
+    DESTINATION "include/dqrobotics/interfaces/coppeliasim") 

--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
@@ -23,7 +23,7 @@ Contributors:
    1. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
         - Responsible for the original implementation.
 */
-
+#pragma once
 #include <dqrobotics/DQ.h>
 #include <string>
 #include <vector>
@@ -35,11 +35,6 @@ namespace DQ_robotics
 class DQ_CoppeliaSimInterface
 {
 public:
-    enum class REFERENCE
-    {
-        BODY_FRAME,
-        ABSOLUTE_FRAME
-    };
     virtual ~DQ_CoppeliaSimInterface() = default;
     virtual bool connect(const std::string& host, const int& port, const int&TIMEOUT_IN_MILISECONDS) = 0;
     virtual void trigger_next_simulation_step() const = 0;

--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
@@ -34,9 +34,12 @@ namespace DQ_robotics
 {
 class DQ_CoppeliaSimInterface
 {
-protected:
-    DQ_CoppeliaSimInterface() = default;
 public:
+    enum class REFERENCE
+    {
+        BODY_FRAME,
+        ABSOLUTE_FRAME
+    };
     virtual ~DQ_CoppeliaSimInterface() = default;
     virtual bool connect(const std::string& host, const int& port, const int&TIMEOUT_IN_MILISECONDS) = 0;
     virtual void trigger_next_simulation_step() const = 0;
@@ -66,6 +69,8 @@ public:
     virtual void     set_joint_torques(const std::vector<std::string>& jointnames, const VectorXd& torques) = 0;
     virtual VectorXd get_joint_torques(const std::vector<std::string>& jointnames) = 0;
 
+protected:
+    DQ_CoppeliaSimInterface() = default;
 };
 
 }

--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
@@ -38,10 +38,9 @@ protected:
 public:
     virtual ~DQ_CoppeliaSimInterface() = default;
     virtual bool connect(const std::string& host, const int& port, const int&TIMEOUT_IN_MILISECONDS) = 0;
-    virtual void set_stepping_mode(const bool& flag) = 0;
-    virtual void trigger_next_simulation_step() = 0;
-    virtual void start_simulation() = 0;
-    virtual void stop_simulation()  = 0;
+    virtual void trigger_next_simulation_step() const = 0;
+    virtual void start_simulation() const = 0;
+    virtual void stop_simulation()  const = 0;
 
     virtual int get_object_handle(const std::string& objectname) = 0;
     virtual std::vector<int> get_object_handles(const std::vector<std::string>& objectnames) = 0;

--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
@@ -1,0 +1,70 @@
+/**
+(C) Copyright 2024 DQ Robotics Developers
+
+This file is part of DQ Robotics.
+
+    DQ Robotics is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    DQ Robotics is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+
+DQ Robotics website: dqrobotics.github.io
+
+Contributors:
+
+   1. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+        - Responsible for the original implementation.
+*/
+
+#include <dqrobotics/DQ.h>
+#include<string>
+
+using namespace Eigen;
+
+namespace DQ_robotics
+{
+class DQ_CoppeliaSimInterface
+{
+protected:
+    DQ_CoppeliaSimInterface() = default;
+public:
+    virtual ~DQ_CoppeliaSimInterface() = default;
+    virtual bool connect(const std::string& host, const int& port, const int&TIMEOUT_IN_MILISECONDS) = 0;
+    virtual void set_stepping_mode(const bool& flag) = 0;
+    virtual void trigger_next_simulation_step() = 0;
+    virtual void start_simulation() = 0;
+    virtual void stop_simulation()  = 0;
+
+    virtual int get_object_handle(const std::string& objectname) = 0;
+    virtual std::vector<int> get_object_handles(const std::vector<std::string>& objectnames) = 0;
+
+    virtual DQ   get_object_translation(const std::string& objectname) = 0;
+    virtual void set_object_translation(const std::string& objectname, const DQ& t) = 0;
+
+    virtual DQ   get_object_rotation   (const std::string& objectname) = 0;
+    virtual void set_object_rotation   (const std::string& objectname, const DQ& r) = 0;
+
+    virtual DQ   get_object_pose       (const std::string& objectname) = 0;
+    virtual void set_object_pose       (const std::string& objectname, const DQ& h) = 0;
+
+    virtual VectorXd get_joint_positions(const std::vector<std::string>& jointnames) = 0;
+    virtual void     set_joint_positions(const std::vector<std::string>& jointnames, const VectorXd& joint_positions) = 0;
+    virtual void     set_joint_target_positions(const std::vector<std::string>& jointnames, const VectorXd& joint_target_positions) = 0;
+
+    virtual VectorXd get_joint_velocities(const std::vector<std::string>& jointnames) = 0;
+    virtual void     set_joint_target_velocities(const std::vector<std::string>& jointnames, const VectorXd& joint_target_velocities) = 0;
+
+    virtual void     set_joint_torques(const std::vector<std::string>& jointnames, const VectorXd& torques) = 0;
+    virtual VectorXd get_joint_torques(const std::vector<std::string>& jointnames) = 0;
+
+};
+
+}

--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
@@ -40,6 +40,7 @@ public:
     virtual ~DQ_CoppeliaSimInterface() = default;
     virtual bool connect(const std::string& host, const int& port, const int&TIMEOUT_IN_MILISECONDS) = 0;
     virtual void trigger_next_simulation_step() const = 0;
+    virtual void set_stepping_mode(const bool& flag) const = 0;
     virtual void start_simulation() const = 0;
     virtual void stop_simulation()  const = 0;
 

--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
@@ -25,7 +25,8 @@ Contributors:
 */
 
 #include <dqrobotics/DQ.h>
-#include<string>
+#include <string>
+#include <vector>
 
 using namespace Eigen;
 


### PR DESCRIPTION
![](https://img.shields.io/badge/type-high_priority-red)![](https://img.shields.io/badge/status-experimental-red)![](https://img.shields.io/badge/warning-internal_modifications-yellow)

@dqrobotics/developers 

This PR proposes the abstract class `DQ_CoppeliaSimInterface` based on https://github.com/dqrobotics/matlab/pull/112, and it is related to https://github.com/dqrobotics/cpp-interface-coppeliasim/issues/1.

This abstract class will enable the new concrete class `DQ_CoppeliaSimZmqInterface`, which is based on my [unofficial version](https://github.com/juanjqo/dqrobotics-interface-coppeliasim/tree/dqrobotics). 

<img src="https://github.com/user-attachments/assets/bc1dbaa9-3590-41c9-ad51-dd754d2f33c0" alt="drawing" width="400"/>

Best regards, 

Juancho


