### PR TITLE
This PR updates the name of the methods to set and get the torques to match the Matlab implementation.

### DIFF
--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
@@ -61,8 +61,8 @@ public:
     virtual VectorXd get_joint_velocities(const std::vector<std::string>& jointnames) = 0;
     virtual void     set_joint_target_velocities(const std::vector<std::string>& jointnames, const VectorXd& joint_target_velocities) = 0;
 
-    virtual void     set_joint_torques(const std::vector<std::string>& jointnames, const VectorXd& torques) = 0;
-    virtual VectorXd get_joint_torques(const std::vector<std::string>& jointnames) = 0;
+    virtual void     set_joint_target_forces(const std::vector<std::string>& jointnames, const VectorXd& forces) = 0;
+    virtual VectorXd get_joint_forces(const std::vector<std::string>& jointnames) = 0;
 
 protected:
     DQ_CoppeliaSimInterface() = default;


### PR DESCRIPTION
Hi @dqrobotics/developers,

This PR updates the name of the methods to set and get the torques to match the [Matlab implementation](https://github.com/dqrobotics/matlab-interface-coppeliasim/blob/b7c38cb027d4868b05562472ff0c85467ab603df/interfaces/coppeliasim/DQ_CoppeliaSimInterface.m#L102C29-L102C45). Specifically, the method `set_joint_torques` is renamed as `set_joint_target_forces`, and `get_joint_torques` as `get_joint_forces`.

Kind regards, 

Juancho