### PR TITLE
This PR adds the `DQ_CoppeliaSimRobot` abstract class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,4 +8,5 @@ set (CMAKE_CXX_STANDARD 11)
 
 INSTALL(FILES
     include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h
+    include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimRobot.h
     DESTINATION "include/dqrobotics/interfaces/coppeliasim") 

--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimRobot.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimRobot.h
@@ -45,6 +45,8 @@ public:
     virtual  VectorXd get_configuration_forces() = 0;
 protected:
     DQ_CoppeliaSimRobot() = default;
+    std::string robot_name_;
+    std::shared_ptr<DQ_CoppeliaSimInterface> coppeliasim_interface_;
 };
 
 }

--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimRobot.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimRobot.h
@@ -1,0 +1,50 @@
+/**
+(C) Copyright 2011-2025 DQ Robotics Developers
+
+This file is part of DQ Robotics.
+
+    DQ Robotics is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    DQ Robotics is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+
+DQ Robotics website: dqrobotics.github.io
+
+Contributors:
+
+   1. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+        - Responsible for the original implementation.
+*/
+#pragma once
+#include <dqrobotics/DQ.h>
+#include <string>
+#include <vector>
+
+using namespace Eigen;
+
+namespace DQ_robotics
+{
+class DQ_CoppeliaSimRobot
+{
+public:
+    virtual ~DQ_CoppeliaSimRobot() = default;
+    virtual void set_configuration(const VectorXd& configuration) = 0;
+    virtual void set_target_configuration(const VectorXd& target_configuration) = 0;
+    virtual  VectorXd get_configuration() = 0;
+    virtual void set_target_configuration_velocities(const VectorXd& target_configuration_velocities) = 0; 
+    virtual  VectorXd get_configuration_velocities() = 0;
+    virtual void set_target_configuration_forces(const VectorXd& target_configuration_forces) = 0; 
+    virtual  VectorXd get_configuration_forces() = 0;
+protected:
+    DQ_CoppeliaSimRobot() = default;
+};
+
+}

--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimRobot.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimRobot.h
@@ -25,6 +25,7 @@ Contributors:
 */
 #pragma once
 #include <dqrobotics/DQ.h>
+#include <dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimInterface.h>
 #include <string>
 #include <memory>
 

--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimRobot.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimRobot.h
@@ -26,7 +26,7 @@ Contributors:
 #pragma once
 #include <dqrobotics/DQ.h>
 #include <string>
-#include <vector>
+#include <memory>
 
 using namespace Eigen;
 

--- a/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimRobot.h
+++ b/include/dqrobotics/interfaces/coppeliasim/DQ_CoppeliaSimRobot.h
@@ -38,10 +38,10 @@ public:
     virtual ~DQ_CoppeliaSimRobot() = default;
     virtual void set_configuration(const VectorXd& configuration) = 0;
     virtual void set_target_configuration(const VectorXd& target_configuration) = 0;
-    virtual  VectorXd get_configuration() = 0;
     virtual void set_target_configuration_velocities(const VectorXd& target_configuration_velocities) = 0; 
-    virtual  VectorXd get_configuration_velocities() = 0;
     virtual void set_target_configuration_forces(const VectorXd& target_configuration_forces) = 0; 
+    virtual  VectorXd get_configuration() = 0;
+    virtual  VectorXd get_configuration_velocities() = 0;
     virtual  VectorXd get_configuration_forces() = 0;
 protected:
     DQ_CoppeliaSimRobot() = default;


### PR DESCRIPTION
@dqrobotics/developers 

Hi @mmmarinho, 

This PR adds the new `DQ_CoppeliaSimRobot` abstract class for the C++ version (The class is already in the Matlab implementation https://github.com/dqrobotics/matlab-interface-coppeliasim/pull/2). This class will enable the concrete `DQ_CoppeliaSimRobotZMQ` class, which I'll propose in a future PR. 

Kind regards, 

Juancho

### Proposal:

(The `DQ_CoppeliaSimRobotZMQ` class is not proposed in this PR).

<img src="https://github.com/user-attachments/assets/bc27ee03-6b10-4d4c-bc8a-556670a0a096" alt="drawing" width="300"/>
